### PR TITLE
+ fix absolute path Makefile

### DIFF
--- a/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/AJupiter.toolbox/.project
+++ b/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/AJupiter.toolbox/.project
@@ -23,7 +23,7 @@
 		<link>
 			<name>BufferStateSpace.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/BufferStateSpace.tla</location>
+			<location>PARENT-1-PROJECT_LOC/BufferStateSpace.tla</location>
 		</link>
 		<link>
 			<name>CSComm.tla</name>
@@ -53,7 +53,7 @@
 		<link>
 			<name>Op.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/Op.tla</location>
+			<location>PARENT-1-PROJECT_LOC/Op.tla</location>
 		</link>
 		<link>
 			<name>OpOperators.tla</name>
@@ -73,7 +73,7 @@
 		<link>
 			<name>SystemModel.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SystemModel.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SystemModel.tla</location>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/AJupiterExtended.toolbox/.project
+++ b/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/AJupiterExtended.toolbox/.project
@@ -23,7 +23,7 @@
 		<link>
 			<name>BufferStateSpace.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/BufferStateSpace.tla</location>
+			<location>PARENT-1-PROJECT_LOC/BufferStateSpace.tla</location>
 		</link>
 		<link>
 			<name>CSComm.tla</name>
@@ -53,7 +53,7 @@
 		<link>
 			<name>Op.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/Op.tla</location>
+			<location>PARENT-1-PROJECT_LOC/Op.tla</location>
 		</link>
 		<link>
 			<name>OpOperators.tla</name>
@@ -73,7 +73,7 @@
 		<link>
 			<name>SystemModel.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SystemModel.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SystemModel.tla</location>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/AJupiterH.toolbox/.project
+++ b/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/AJupiterH.toolbox/.project
@@ -28,7 +28,7 @@
 		<link>
 			<name>BufferStateSpace.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/BufferStateSpace.tla</location>
+			<location>PARENT-1-PROJECT_LOC/BufferStateSpace.tla</location>
 		</link>
 		<link>
 			<name>CSComm.tla</name>
@@ -53,7 +53,7 @@
 		<link>
 			<name>Op.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/Op.tla</location>
+			<location>PARENT-1-PROJECT_LOC/Op.tla</location>
 		</link>
 		<link>
 			<name>OpOperators.tla</name>
@@ -73,7 +73,7 @@
 		<link>
 			<name>SystemModel.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SystemModel.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SystemModel.tla</location>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/AJupiterImplXJupiter.toolbox/.project
+++ b/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/AJupiterImplXJupiter.toolbox/.project
@@ -28,7 +28,7 @@
 		<link>
 			<name>BufferStateSpace.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/BufferStateSpace.tla</location>
+			<location>PARENT-1-PROJECT_LOC/BufferStateSpace.tla</location>
 		</link>
 		<link>
 			<name>CSComm.tla</name>
@@ -43,7 +43,7 @@
 		<link>
 			<name>GraphStateSpace.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/GraphStateSpace.tla</location>
+			<location>PARENT-1-PROJECT_LOC/GraphStateSpace.tla</location>
 		</link>
 		<link>
 			<name>GraphsUtil.tla</name>
@@ -68,7 +68,7 @@
 		<link>
 			<name>Op.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/Op.tla</location>
+			<location>PARENT-1-PROJECT_LOC/Op.tla</location>
 		</link>
 		<link>
 			<name>OpOperators.tla</name>
@@ -93,7 +93,7 @@
 		<link>
 			<name>SystemModel.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SystemModel.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SystemModel.tla</location>
 		</link>
 		<link>
 			<name>XJupiter.tla</name>

--- a/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/AbsJupiter.toolbox/.project
+++ b/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/AbsJupiter.toolbox/.project
@@ -53,7 +53,7 @@
 		<link>
 			<name>Op.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/Op.tla</location>
+			<location>PARENT-1-PROJECT_LOC/Op.tla</location>
 		</link>
 		<link>
 			<name>OpOperators.tla</name>
@@ -68,7 +68,7 @@
 		<link>
 			<name>SetStateSpace.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SetStateSpace.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SetStateSpace.tla</location>
 		</link>
 		<link>
 			<name>SetUtils.tla</name>
@@ -78,7 +78,7 @@
 		<link>
 			<name>SystemModel.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SystemModel.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SystemModel.tla</location>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/BufferStateSpace.toolbox/.project
+++ b/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/BufferStateSpace.toolbox/.project
@@ -23,17 +23,17 @@
 		<link>
 			<name>FunctionUtils.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/FunctionUtils.tla</location>
+			<location>PARENT-1-PROJECT_LOC/FunctionUtils.tla</location>
 		</link>
 		<link>
 			<name>SequenceUtils.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SequenceUtils.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SequenceUtils.tla</location>
 		</link>
 		<link>
 			<name>SetUtils.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SetUtils.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SetUtils.tla</location>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/CJupiter.toolbox/.project
+++ b/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/CJupiter.toolbox/.project
@@ -33,7 +33,7 @@
 		<link>
 			<name>GraphStateSpace.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/GraphStateSpace.tla</location>
+			<location>PARENT-1-PROJECT_LOC/GraphStateSpace.tla</location>
 		</link>
 		<link>
 			<name>GraphsUtil.tla</name>
@@ -63,7 +63,7 @@
 		<link>
 			<name>Op.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/Op.tla</location>
+			<location>PARENT-1-PROJECT_LOC/Op.tla</location>
 		</link>
 		<link>
 			<name>OpOperators.tla</name>
@@ -88,7 +88,7 @@
 		<link>
 			<name>SystemModel.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SystemModel.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SystemModel.tla</location>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/CJupiterH.toolbox/.project
+++ b/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/CJupiterH.toolbox/.project
@@ -38,7 +38,7 @@
 		<link>
 			<name>GraphsUtil.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/GraphsUtil.tla</location>
+			<location>PARENT-1-PROJECT_LOC/GraphsUtil.tla</location>
 		</link>
 		<link>
 			<name>JupiterCtx.tla</name>
@@ -78,7 +78,7 @@
 		<link>
 			<name>StateSpace.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/StateSpace.tla</location>
+			<location>PARENT-1-PROJECT_LOC/StateSpace.tla</location>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/CJupiterImplAbsJupiter.toolbox/.project
+++ b/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/CJupiterImplAbsJupiter.toolbox/.project
@@ -43,7 +43,7 @@
 		<link>
 			<name>GraphStateSpace.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/GraphStateSpace.tla</location>
+			<location>PARENT-1-PROJECT_LOC/GraphStateSpace.tla</location>
 		</link>
 		<link>
 			<name>GraphsUtil.tla</name>
@@ -73,7 +73,7 @@
 		<link>
 			<name>Op.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/Op.tla</location>
+			<location>PARENT-1-PROJECT_LOC/Op.tla</location>
 		</link>
 		<link>
 			<name>OpOperators.tla</name>
@@ -88,7 +88,7 @@
 		<link>
 			<name>SetStateSpace.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SetStateSpace.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SetStateSpace.tla</location>
 		</link>
 		<link>
 			<name>SetUtils.tla</name>
@@ -103,7 +103,7 @@
 		<link>
 			<name>SystemModel.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SystemModel.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SystemModel.tla</location>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/CSComm.toolbox/.project
+++ b/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/CSComm.toolbox/.project
@@ -23,17 +23,17 @@
 		<link>
 			<name>FunctionUtils.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/FunctionUtils.tla</location>
+			<location>PARENT-1-PROJECT_LOC/FunctionUtils.tla</location>
 		</link>
 		<link>
 			<name>SequenceUtils.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SequenceUtils.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SequenceUtils.tla</location>
 		</link>
 		<link>
 			<name>SetUtils.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SetUtils.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SetUtils.tla</location>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/GraphStateSpace.toolbox/.project
+++ b/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/GraphStateSpace.toolbox/.project
@@ -53,7 +53,7 @@
 		<link>
 			<name>Op.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/Op.tla</location>
+			<location>PARENT-1-PROJECT_LOC/Op.tla</location>
 		</link>
 		<link>
 			<name>OpOperators.tla</name>
@@ -78,7 +78,7 @@
 		<link>
 			<name>SystemModel.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SystemModel.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SystemModel.tla</location>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/JupiterCtx.toolbox/.project
+++ b/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/JupiterCtx.toolbox/.project
@@ -43,7 +43,7 @@
 		<link>
 			<name>Op.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/Op.tla</location>
+			<location>PARENT-1-PROJECT_LOC/Op.tla</location>
 		</link>
 		<link>
 			<name>OpOperators.tla</name>
@@ -63,7 +63,7 @@
 		<link>
 			<name>SystemModel.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SystemModel.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SystemModel.tla</location>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/JupiterInterface.toolbox/.project
+++ b/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/JupiterInterface.toolbox/.project
@@ -38,7 +38,7 @@
 		<link>
 			<name>Op.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/Op.tla</location>
+			<location>PARENT-1-PROJECT_LOC/Op.tla</location>
 		</link>
 		<link>
 			<name>OpOperators.tla</name>
@@ -58,7 +58,7 @@
 		<link>
 			<name>SystemModel.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SystemModel.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SystemModel.tla</location>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/JupiterSerial.toolbox/.project
+++ b/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/JupiterSerial.toolbox/.project
@@ -48,7 +48,7 @@
 		<link>
 			<name>Op.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/Op.tla</location>
+			<location>PARENT-1-PROJECT_LOC/Op.tla</location>
 		</link>
 		<link>
 			<name>OpOperators.tla</name>
@@ -68,7 +68,7 @@
 		<link>
 			<name>SystemModel.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SystemModel.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SystemModel.tla</location>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/OT.toolbox/.project
+++ b/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/OT.toolbox/.project
@@ -18,7 +18,7 @@
 		<link>
 			<name>FunctionUtils.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/FunctionUtils.tla</location>
+			<location>PARENT-1-PROJECT_LOC/FunctionUtils.tla</location>
 		</link>
 		<link>
 			<name>OT.tla</name>
@@ -28,27 +28,27 @@
 		<link>
 			<name>Op.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/Op.tla</location>
+			<location>PARENT-1-PROJECT_LOC/Op.tla</location>
 		</link>
 		<link>
 			<name>OpOperators.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/OpOperators.tla</location>
+			<location>PARENT-1-PROJECT_LOC/OpOperators.tla</location>
 		</link>
 		<link>
 			<name>SequenceUtils.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SequenceUtils.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SequenceUtils.tla</location>
 		</link>
 		<link>
 			<name>SetUtils.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SetUtils.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SetUtils.tla</location>
 		</link>
 		<link>
 			<name>SystemModel.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SystemModel.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SystemModel.tla</location>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SetStateSpace.toolbox/.project
+++ b/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SetStateSpace.toolbox/.project
@@ -18,47 +18,47 @@
 		<link>
 			<name>CSComm.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/CSComm.tla</location>
+			<location>PARENT-1-PROJECT_LOC/CSComm.tla</location>
 		</link>
 		<link>
 			<name>FunctionUtils.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/FunctionUtils.tla</location>
+			<location>PARENT-1-PROJECT_LOC/FunctionUtils.tla</location>
 		</link>
 		<link>
 			<name>JupiterCtx.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/JupiterCtx.tla</location>
+			<location>PARENT-1-PROJECT_LOC/JupiterCtx.tla</location>
 		</link>
 		<link>
 			<name>JupiterInterface.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/JupiterInterface.tla</location>
+			<location>PARENT-1-PROJECT_LOC/JupiterInterface.tla</location>
 		</link>
 		<link>
 			<name>JupiterSerial.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/JupiterSerial.tla</location>
+			<location>PARENT-1-PROJECT_LOC/JupiterSerial.tla</location>
 		</link>
 		<link>
 			<name>OT.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/OT.tla</location>
+			<location>PARENT-1-PROJECT_LOC/OT.tla</location>
 		</link>
 		<link>
 			<name>Op.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/Op.tla</location>
+			<location>PARENT-1-PROJECT_LOC/Op.tla</location>
 		</link>
 		<link>
 			<name>OpOperators.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/OpOperators.tla</location>
+			<location>PARENT-1-PROJECT_LOC/OpOperators.tla</location>
 		</link>
 		<link>
 			<name>SequenceUtils.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SequenceUtils.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SequenceUtils.tla</location>
 		</link>
 		<link>
 			<name>SetStateSpace.tla</name>
@@ -68,12 +68,12 @@
 		<link>
 			<name>SetUtils.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SetUtils.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SetUtils.tla</location>
 		</link>
 		<link>
 			<name>SystemModel.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SystemModel.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SystemModel.tla</location>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SystemModel.toolbox/.project
+++ b/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SystemModel.toolbox/.project
@@ -18,17 +18,17 @@
 		<link>
 			<name>FunctionUtils.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/FunctionUtils.tla</location>
+			<location>PARENT-1-PROJECT_LOC/FunctionUtils.tla</location>
 		</link>
 		<link>
 			<name>SequenceUtils.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SequenceUtils.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SequenceUtils.tla</location>
 		</link>
 		<link>
 			<name>SetUtils.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SetUtils.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SetUtils.tla</location>
 		</link>
 		<link>
 			<name>SystemModel.tla</name>

--- a/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/XJupiter.toolbox/.project
+++ b/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/XJupiter.toolbox/.project
@@ -28,7 +28,7 @@
 		<link>
 			<name>GraphStateSpace.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/GraphStateSpace.tla</location>
+			<location>PARENT-1-PROJECT_LOC/GraphStateSpace.tla</location>
 		</link>
 		<link>
 			<name>GraphsUtil.tla</name>
@@ -53,7 +53,7 @@
 		<link>
 			<name>Op.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/Op.tla</location>
+			<location>PARENT-1-PROJECT_LOC/Op.tla</location>
 		</link>
 		<link>
 			<name>OpOperators.tla</name>
@@ -78,7 +78,7 @@
 		<link>
 			<name>SystemModel.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SystemModel.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SystemModel.tla</location>
 		</link>
 		<link>
 			<name>TLCUtils.tla</name>

--- a/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/XJupiterExtended.toolbox/.project
+++ b/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/XJupiterExtended.toolbox/.project
@@ -28,7 +28,7 @@
 		<link>
 			<name>GraphStateSpace.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/GraphStateSpace.tla</location>
+			<location>PARENT-1-PROJECT_LOC/GraphStateSpace.tla</location>
 		</link>
 		<link>
 			<name>GraphsUtil.tla</name>
@@ -58,7 +58,7 @@
 		<link>
 			<name>Op.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/Op.tla</location>
+			<location>PARENT-1-PROJECT_LOC/Op.tla</location>
 		</link>
 		<link>
 			<name>OpOperators.tla</name>
@@ -83,7 +83,7 @@
 		<link>
 			<name>SystemModel.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SystemModel.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SystemModel.tla</location>
 		</link>
 		<link>
 			<name>XJupiter.tla</name>

--- a/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/XJupiterH.toolbox/.project
+++ b/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/XJupiterH.toolbox/.project
@@ -28,12 +28,12 @@
 		<link>
 			<name>GraphStateSpace.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/GraphStateSpace.tla</location>
+			<location>PARENT-1-PROJECT_LOC/GraphStateSpace.tla</location>
 		</link>
 		<link>
 			<name>GraphsUtil.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/GraphsUtil.tla</location>
+			<location>PARENT-1-PROJECT_LOC/GraphsUtil.tla</location>
 		</link>
 		<link>
 			<name>JupiterCtx.tla</name>
@@ -53,7 +53,7 @@
 		<link>
 			<name>Op.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/Op.tla</location>
+			<location>PARENT-1-PROJECT_LOC/Op.tla</location>
 		</link>
 		<link>
 			<name>OpOperators.tla</name>
@@ -73,12 +73,12 @@
 		<link>
 			<name>StateSpace.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/StateSpace.tla</location>
+			<location>PARENT-1-PROJECT_LOC/StateSpace.tla</location>
 		</link>
 		<link>
 			<name>SystemModel.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SystemModel.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SystemModel.tla</location>
 		</link>
 		<link>
 			<name>TLCUtils.tla</name>

--- a/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/XJupiterImplCJupiter.toolbox/.project
+++ b/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/XJupiterImplCJupiter.toolbox/.project
@@ -33,7 +33,7 @@
 		<link>
 			<name>GraphStateSpace.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/GraphStateSpace.tla</location>
+			<location>PARENT-1-PROJECT_LOC/GraphStateSpace.tla</location>
 		</link>
 		<link>
 			<name>GraphsUtil.tla</name>
@@ -63,7 +63,7 @@
 		<link>
 			<name>Op.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/Op.tla</location>
+			<location>PARENT-1-PROJECT_LOC/Op.tla</location>
 		</link>
 		<link>
 			<name>OpOperators.tla</name>
@@ -88,7 +88,7 @@
 		<link>
 			<name>SystemModel.tla</name>
 			<type>1</type>
-			<location>/home/hengxin/Git-Projects/github-projects/tlaplus-lamport-projects/tlaplus-projects/Hengfeng-Wei/Wei-jupiter-tla/SystemModel.tla</location>
+			<location>PARENT-1-PROJECT_LOC/SystemModel.tla</location>
 		</link>
 		<link>
 			<name>TLCUtils.tla</name>

--- a/tlaplus-projects/Makefile
+++ b/tlaplus-projects/Makefile
@@ -1,0 +1,7 @@
+# The .project files created by toolbox may mistakenly using absolute paths,
+# like `/home/user/project/mycode.tla', which makes the project imported 
+# improperly if the project's location changed or it was cloned by others.
+# Use this script to fix it!
+
+fix-path:
+	find . -type f -name .project | xargs sed -i 's,<location>/home.*/\(.*.tla\)</location>,<location>PARENT-1-PROJECT_LOC/\1</location>,g'


### PR DESCRIPTION
The `.project` files created by toolbox may mistakenly using absolute paths, like `/home/user/project/mycode.tla`, which makes the project imported  improperly if the project's location changed or it was cloned by others.

I wrote a Makefile to fix this problem. The Makefile find all `.project` files and do the substitution.
```
find . -type f -name .project | xargs sed -i 's,<location>/home.*/\(.*.tla\)</location>,<location>PARENT-1-PROJECT_LOC/\1</location>,g'
```